### PR TITLE
Add virtual environment setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -4,11 +4,19 @@ This simple Flask application lets you store links to PDF articles and leave com
 
 ## Setup
 
-1. Install dependencies:
+1. Create and activate a virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+   Alternatively, run `./create_venv.sh` to set up the environment automatically.
+
+2. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the app:
+
+3. Run the app:
    ```bash
    flask --app app run
    ```

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Virtual environment created at .venv and dependencies installed."


### PR DESCRIPTION
## Summary
- add a script for creating a virtual environment and installing requirements
- document the virtual environment setup process in the README
- ignore the virtual environment and bytecode files

## Testing
- `./create_venv.sh`
- `source .venv/bin/activate && python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b219198f483218aa361143479cce5